### PR TITLE
fix: 구매내역 id 컬럼 이름 변경

### DIFF
--- a/root/pay-service/src/main/java/com/example/payservice/entity/PurchaseHistory.java
+++ b/root/pay-service/src/main/java/com/example/payservice/entity/PurchaseHistory.java
@@ -13,7 +13,7 @@ import java.time.LocalDateTime;
 public class PurchaseHistory extends TimeStamped {
 
     @Id
-    @Column(name = "postpaid_history_id")
+    @Column(name = "purchase_history_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 


### PR DESCRIPTION
- PurchaseHistory 엔티티의 id 이름 변경