### PR TITLE
feat: 이용권 승인 구현

### DIFF
--- a/root/ticket-service/src/main/java/com/example/ticketservice/client/MemberServiceClient.java
+++ b/root/ticket-service/src/main/java/com/example/ticketservice/client/MemberServiceClient.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 @FeignClient(name = "member-service")
 public interface MemberServiceClient {
 
+    // TODO: 추후 구현 필요
     @GetMapping("/api/v1/members/{memberId}")
     BaseResponseDto<MemberInfoResponseDto> getMemberInfo(@PathVariable long memberId);
 }

--- a/root/ticket-service/src/main/java/com/example/ticketservice/client/MemberServiceClient.java
+++ b/root/ticket-service/src/main/java/com/example/ticketservice/client/MemberServiceClient.java
@@ -1,0 +1,11 @@
+package com.example.ticketservice.client;
+
+import com.example.ticketservice.client.dto.response.MemberInfoResponseDto;
+import com.example.ticketservice.dto.BaseResponseDto;
+import org.springframework.cloud.openfeign.FeignClient;
+
+@FeignClient(name = "member-service")
+public interface MemberServiceClient {
+
+    BaseResponseDto<MemberInfoResponseDto> getMemberInfo(long memberId);
+}

--- a/root/ticket-service/src/main/java/com/example/ticketservice/client/MemberServiceClient.java
+++ b/root/ticket-service/src/main/java/com/example/ticketservice/client/MemberServiceClient.java
@@ -3,9 +3,12 @@ package com.example.ticketservice.client;
 import com.example.ticketservice.client.dto.response.MemberInfoResponseDto;
 import com.example.ticketservice.dto.BaseResponseDto;
 import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 
 @FeignClient(name = "member-service")
 public interface MemberServiceClient {
 
-    BaseResponseDto<MemberInfoResponseDto> getMemberInfo(long memberId);
+    @GetMapping("/api/v1/members/{memberId}")
+    BaseResponseDto<MemberInfoResponseDto> getMemberInfo(@PathVariable long memberId);
 }

--- a/root/ticket-service/src/main/java/com/example/ticketservice/client/dto/response/MemberInfoResponseDto.java
+++ b/root/ticket-service/src/main/java/com/example/ticketservice/client/dto/response/MemberInfoResponseDto.java
@@ -1,8 +1,12 @@
 package com.example.ticketservice.client.dto.response;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@AllArgsConstructor
+@NoArgsConstructor
 public class MemberInfoResponseDto {
     private String memberName;
     private String phoneNumber;

--- a/root/ticket-service/src/main/java/com/example/ticketservice/client/dto/response/MemberInfoResponseDto.java
+++ b/root/ticket-service/src/main/java/com/example/ticketservice/client/dto/response/MemberInfoResponseDto.java
@@ -1,0 +1,9 @@
+package com.example.ticketservice.client.dto.response;
+
+import lombok.Getter;
+
+@Getter
+public class MemberInfoResponseDto {
+    private String memberName;
+    private String phoneNumber;
+}

--- a/root/ticket-service/src/main/java/com/example/ticketservice/controller/AdminTicketController.java
+++ b/root/ticket-service/src/main/java/com/example/ticketservice/controller/AdminTicketController.java
@@ -76,7 +76,7 @@ public class AdminTicketController {
                 .body(new BaseResponseDto<>(ticketService.getTicketInfo(ticketId)));
     }
 
-    @GetMapping("/member/{centerId}/unapproved")
+    @GetMapping("/members/unapproved/{centerId}")
     public ResponseEntity<BaseResponseDto<List<UnapprovedUserTicketListResponseDto>>> getUnapprovedUserTicketList(@PathVariable long centerId) {
         return ResponseEntity.status(HttpStatus.OK)
                 .body(new BaseResponseDto<>(ticketService.getUnapprovedUserTicketList(centerId)));

--- a/root/ticket-service/src/main/java/com/example/ticketservice/controller/AdminTicketController.java
+++ b/root/ticket-service/src/main/java/com/example/ticketservice/controller/AdminTicketController.java
@@ -81,4 +81,11 @@ public class AdminTicketController {
         return ResponseEntity.status(HttpStatus.OK)
                 .body(new BaseResponseDto<>(ticketService.getUnapprovedUserTicketList(centerId)));
     }
+
+    @PatchMapping("/members/{userTicketId}/approve")
+    public ResponseEntity<BaseResponseDto<Void>> approveUserTicket(@PathVariable long userTicketId) {
+        ticketService.approveUserTicket(userTicketId);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(new BaseResponseDto<>());
+    }
 }

--- a/root/ticket-service/src/main/java/com/example/ticketservice/controller/AdminTicketController.java
+++ b/root/ticket-service/src/main/java/com/example/ticketservice/controller/AdminTicketController.java
@@ -1,0 +1,78 @@
+package com.example.ticketservice.controller;
+
+import com.example.ticketservice.dto.BaseResponseDto;
+import com.example.ticketservice.dto.request.TicketCreateRequestDto;
+import com.example.ticketservice.dto.request.TicketUpdateRequestDto;
+import com.example.ticketservice.dto.response.*;
+import com.example.ticketservice.service.TicketService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/admin/tickets")
+public class AdminTicketController {
+    private final TicketService ticketService;
+
+    @GetMapping("/management/{centerId}/{ticketId}")
+    public ResponseEntity<BaseResponseDto<List<TicketResponseDto>>> getTicketList(@PathVariable long centerId,
+                                                                                  @PathVariable long ticketId) {
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(new BaseResponseDto<>(ticketService.getTicketList(centerId, ticketId)));
+    }
+
+    @PostMapping("/management/{centerId}")
+    public ResponseEntity<BaseResponseDto<TicketCreateResponseDto>> createTicket(@PathVariable long centerId,
+                                                                                 @RequestPart TicketCreateRequestDto requestDto,
+                                                                                 @RequestPart(required = false) MultipartFile ticketImage) {
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(new BaseResponseDto<>(ticketService.createTicket(centerId, requestDto, ticketImage)));
+    }
+
+    @GetMapping("/management/{ticketId}")
+    public ResponseEntity<BaseResponseDto<TicketDetailResponseDto>> getTicketDetail(@PathVariable long ticketId) {
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(new BaseResponseDto<>(ticketService.getTicketDetail(ticketId)));
+    }
+
+    @PatchMapping("/management/{ticketId}")
+    public ResponseEntity<BaseResponseDto<TicketDetailResponseDto>> updateTicket(@PathVariable long ticketId,
+                                                                                 @RequestPart TicketUpdateRequestDto requestDto,
+                                                                                 @RequestPart(required = false) MultipartFile ticketImage) {
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(new BaseResponseDto<>(ticketService.updateTicket(ticketId, requestDto, ticketImage)));
+    }
+
+    @PatchMapping("/management/{ticketId}/upload")
+    public ResponseEntity<BaseResponseDto<Void>> uploadTicket(@PathVariable long ticketId) {
+        ticketService.uploadTicket(ticketId);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(new BaseResponseDto<>());
+    }
+
+    @PatchMapping("/management/{ticketId}/cancel-upload")
+    public ResponseEntity<BaseResponseDto<Void>> cancelUploadTicket(@PathVariable long ticketId) {
+        ticketService.cancelUploadTicket(ticketId);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(new BaseResponseDto<>());
+    }
+
+    @GetMapping("/review/{centerId}/{ticketId}")
+    public ResponseEntity<BaseResponseDto<List<AdminTicketResponseDto>>> getAdminTicketList(@PathVariable long centerId,
+                                                                                            @PathVariable long ticketId) {
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(new BaseResponseDto<>(ticketService.getAdminTicketList(centerId, ticketId)));
+    }
+
+    @GetMapping("/review/{ticketId}")
+    public ResponseEntity<BaseResponseDto<AdminReviewTicketResponseDto>> getTicketInfo(@PathVariable long ticketId) {
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(new BaseResponseDto<>(ticketService.getTicketInfo(ticketId)));
+    }
+}

--- a/root/ticket-service/src/main/java/com/example/ticketservice/controller/AdminTicketController.java
+++ b/root/ticket-service/src/main/java/com/example/ticketservice/controller/AdminTicketController.java
@@ -75,4 +75,10 @@ public class AdminTicketController {
         return ResponseEntity.status(HttpStatus.OK)
                 .body(new BaseResponseDto<>(ticketService.getTicketInfo(ticketId)));
     }
+
+    @GetMapping("/member/{centerId}/unapproved")
+    public ResponseEntity<BaseResponseDto<List<UnapprovedUserTicketListResponseDto>>> getUnapprovedUserTicketList(@PathVariable long centerId) {
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(new BaseResponseDto<>(ticketService.getUnapprovedUserTicketList(centerId)));
+    }
 }

--- a/root/ticket-service/src/main/java/com/example/ticketservice/controller/TicketController.java
+++ b/root/ticket-service/src/main/java/com/example/ticketservice/controller/TicketController.java
@@ -2,19 +2,14 @@ package com.example.ticketservice.controller;
 
 import com.example.ticketservice.common.util.Utils;
 import com.example.ticketservice.dto.BaseResponseDto;
-import com.example.ticketservice.dto.request.TicketCreateRequestDto;
-import com.example.ticketservice.dto.request.TicketUpdateRequestDto;
 import com.example.ticketservice.dto.response.*;
 import com.example.ticketservice.service.TicketService;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
 
-import java.net.URLDecoder;
 import java.util.List;
 import java.util.Map;
 
@@ -25,73 +20,16 @@ public class TicketController {
 
     private final TicketService ticketService;
 
-    @GetMapping("/admin/tickets/management/{centerId}/{ticketId}")
-    public ResponseEntity<BaseResponseDto<List<TicketResponseDto>>> getTicketList(@PathVariable long centerId,
-                                                                                  @PathVariable long ticketId) {
-        return ResponseEntity.status(HttpStatus.OK)
-                .body(new BaseResponseDto<>(ticketService.getTicketList(centerId, ticketId)));
-    }
-
-    @GetMapping("/admin/tickets/review/{centerId}/{ticketId}")
-    public ResponseEntity<BaseResponseDto<List<AdminTicketResponseDto>>> getAdminTicketList(@PathVariable long centerId,
-                                                                                            @PathVariable long ticketId) {
-        return ResponseEntity.status(HttpStatus.OK)
-                .body(new BaseResponseDto<>(ticketService.getAdminTicketList(centerId, ticketId)));
-    }
-
-    @PostMapping("/admin/tickets/management/{centerId}")
-    public ResponseEntity<BaseResponseDto<TicketCreateResponseDto>> createTicket(@PathVariable long centerId,
-                                                                                 @RequestPart TicketCreateRequestDto requestDto,
-                                                                                 @RequestPart(required = false) MultipartFile ticketImage) {
-
-        return ResponseEntity.status(HttpStatus.CREATED)
-                .body(new BaseResponseDto<>(ticketService.createTicket(centerId, requestDto, ticketImage)));
-    }
-
     @PostMapping("/tickets/bookmarks")
     public ResponseEntity<BaseResponseDto<Map<Long, BookmarkScoreTicketResponseDto>>> getBookmarkTicketList(@RequestBody List<Long> centerIdList) {
         return ResponseEntity.status(HttpStatus.OK)
                 .body(new BaseResponseDto<>(ticketService.getBookmarkTicketList(centerIdList)));
     }
 
-    @GetMapping("/admin/tickets/review/{ticketId}")
-    public ResponseEntity<BaseResponseDto<AdminReviewTicketResponseDto>> getTicketInfo(@PathVariable long ticketId) {
-        return ResponseEntity.status(HttpStatus.OK)
-                .body(new BaseResponseDto<>(ticketService.getTicketInfo(ticketId)));
-    }
-
     @GetMapping("/tickets/ios-review/{ticketId}")
     public ResponseEntity<BaseResponseDto<ReviewListTicketResponseDto>> getIOSTicketInfo(@PathVariable long ticketId) {
         return ResponseEntity.status(HttpStatus.OK)
                 .body(new BaseResponseDto<>(ticketService.getIOSTicketInfo(ticketId)));
-    }
-
-    @GetMapping("/admin/tickets/management/{ticketId}")
-    public ResponseEntity<BaseResponseDto<TicketDetailResponseDto>> getTicketDetail(@PathVariable long ticketId) {
-        return ResponseEntity.status(HttpStatus.OK)
-                .body(new BaseResponseDto<>(ticketService.getTicketDetail(ticketId)));
-    }
-
-    @PatchMapping("/admin/tickets/management/{ticketId}")
-    public ResponseEntity<BaseResponseDto<TicketDetailResponseDto>> updateTicket(@PathVariable long ticketId,
-                                                                                @RequestPart TicketUpdateRequestDto requestDto,
-                                                                                @RequestPart(required = false) MultipartFile ticketImage) {
-        return ResponseEntity.status(HttpStatus.OK)
-                .body(new BaseResponseDto<>(ticketService.updateTicket(ticketId, requestDto, ticketImage)));
-    }
-
-    @PatchMapping("/admin/tickets/management/{ticketId}/upload")
-    public ResponseEntity<BaseResponseDto<Void>> uploadTicket(@PathVariable long ticketId) {
-        ticketService.uploadTicket(ticketId);
-        return ResponseEntity.status(HttpStatus.OK)
-                .body(new BaseResponseDto<>());
-    }
-
-    @PatchMapping("/admin/tickets/management/{ticketId}/cancel-upload")
-    public ResponseEntity<BaseResponseDto<Void>> cancelUploadTicket(@PathVariable long ticketId) {
-        ticketService.cancelUploadTicket(ticketId);
-        return ResponseEntity.status(HttpStatus.OK)
-                .body(new BaseResponseDto<>());
     }
 
     @PostMapping("/tickets/{ticketId}/purchase")

--- a/root/ticket-service/src/main/java/com/example/ticketservice/dto/response/UnapprovedUserTicketListResponseDto.java
+++ b/root/ticket-service/src/main/java/com/example/ticketservice/dto/response/UnapprovedUserTicketListResponseDto.java
@@ -2,13 +2,17 @@ package com.example.ticketservice.dto.response;
 
 import com.example.ticketservice.client.dto.response.MemberInfoResponseDto;
 import com.example.ticketservice.entity.UserTicket;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
 @Getter
 @Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class UnapprovedUserTicketListResponseDto {
     private Long userTicketId;
 

--- a/root/ticket-service/src/main/java/com/example/ticketservice/dto/response/UnapprovedUserTicketListResponseDto.java
+++ b/root/ticket-service/src/main/java/com/example/ticketservice/dto/response/UnapprovedUserTicketListResponseDto.java
@@ -1,0 +1,32 @@
+package com.example.ticketservice.dto.response;
+
+import com.example.ticketservice.client.dto.response.MemberInfoResponseDto;
+import com.example.ticketservice.entity.UserTicket;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class UnapprovedUserTicketListResponseDto {
+    private Long userTicketId;
+
+    private String ticketName;
+
+    private String memberName;
+
+    private String phoneNumber;
+
+    private LocalDateTime createdAt;
+
+    public static UnapprovedUserTicketListResponseDto of(UserTicket userTicket, MemberInfoResponseDto memberInfo) {
+        return UnapprovedUserTicketListResponseDto.builder()
+                .userTicketId(userTicket.getId())
+                .ticketName(userTicket.getTicket().getName())
+                .memberName(memberInfo.getMemberName())
+                .phoneNumber(memberInfo.getPhoneNumber())
+                .createdAt(userTicket.getCreatedAt())
+                .build();
+    }
+}

--- a/root/ticket-service/src/main/java/com/example/ticketservice/repository/ticket/UserTicketRepository.java
+++ b/root/ticket-service/src/main/java/com/example/ticketservice/repository/ticket/UserTicketRepository.java
@@ -9,5 +9,5 @@ import java.util.List;
 @Repository
 public interface UserTicketRepository extends JpaRepository<UserTicket, Long> {
 
-    List<UserTicket> findAllByTicketIdAndApproveFalse(long ticketId);
+    List<UserTicket> findAllByTicketIdAndIsApproveFalse(long ticketId);
 }

--- a/root/ticket-service/src/main/java/com/example/ticketservice/repository/ticket/UserTicketRepository.java
+++ b/root/ticket-service/src/main/java/com/example/ticketservice/repository/ticket/UserTicketRepository.java
@@ -4,6 +4,10 @@ import com.example.ticketservice.entity.UserTicket;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface UserTicketRepository extends JpaRepository<UserTicket, Long> {
+
+    List<UserTicket> findAllByTicketIdAndApproveFalse(long ticketId);
 }

--- a/root/ticket-service/src/main/java/com/example/ticketservice/service/TicketService.java
+++ b/root/ticket-service/src/main/java/com/example/ticketservice/service/TicketService.java
@@ -32,4 +32,6 @@ public interface TicketService {
     Long purchaseTicket(long memberId, long ticketId);
 
     List<UnapprovedUserTicketListResponseDto> getUnapprovedUserTicketList(long centerId);
+
+    void approveUserTicket(long userTicketId);
 }

--- a/root/ticket-service/src/main/java/com/example/ticketservice/service/TicketService.java
+++ b/root/ticket-service/src/main/java/com/example/ticketservice/service/TicketService.java
@@ -30,4 +30,6 @@ public interface TicketService {
     void cancelUploadTicket(long ticketId);
 
     Long purchaseTicket(long memberId, long ticketId);
+
+    List<UnapprovedUserTicketListResponseDto> getUnapprovedUserTicketList(long centerId);
 }

--- a/root/ticket-service/src/main/java/com/example/ticketservice/service/TicketServiceImpl.java
+++ b/root/ticket-service/src/main/java/com/example/ticketservice/service/TicketServiceImpl.java
@@ -162,7 +162,7 @@ public class TicketServiceImpl implements TicketService{
         UserTicket userTicket = UserTicket.of(ticket, memberId);
         userTicketRepository.save(userTicket);
 
-        ticket.issue();
+        //ticket.issue();
         return userTicket.getId();
     }
 

--- a/root/ticket-service/src/main/java/com/example/ticketservice/service/TicketServiceImpl.java
+++ b/root/ticket-service/src/main/java/com/example/ticketservice/service/TicketServiceImpl.java
@@ -187,6 +187,17 @@ public class TicketServiceImpl implements TicketService{
                 .toList();
     }
 
+    @Override
+    @Transactional
+    public void approveUserTicket(long userTicketId) {
+        UserTicket userTicket = userTicketRepository.findById(userTicketId)
+                .orElseThrow(() -> new ApiException(ExceptionEnum.USER_TICKET_NOT_EXIST_EXCEPTION));
+        Ticket ticket = userTicket.getTicket();
+
+        userTicket.approve();
+        ticket.issue();
+    }
+
     private float getScore(long centerId) {
         List<Review> reviewList = reviewRepository.findAllByCenterId(centerId);
         if (reviewList.size() == 0) return 0;

--- a/root/ticket-service/src/main/java/com/example/ticketservice/service/TicketServiceImpl.java
+++ b/root/ticket-service/src/main/java/com/example/ticketservice/service/TicketServiceImpl.java
@@ -25,6 +25,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -175,13 +176,14 @@ public class TicketServiceImpl implements TicketService{
     public List<UnapprovedUserTicketListResponseDto> getUnapprovedUserTicketList(long centerId) {
         List<Long> ticketIds = ticketRepository.findAllByCenterId(centerId).stream().map(Ticket::getId).toList();
         List<UserTicket> userTicketList = ticketIds.stream()
-                .flatMap(ticketId -> userTicketRepository.findAllByTicketIdAndApproveFalse(ticketId).stream())
+                .flatMap(ticketId -> userTicketRepository.findAllByTicketIdAndIsApproveFalse(ticketId).stream())
                         .collect(Collectors.toList());
         return userTicketList.stream()
                 .map(userTicket -> {
                     MemberInfoResponseDto memberInfo = memberServiceClient.getMemberInfo(userTicket.getMemberId()).getData();
                     return UnapprovedUserTicketListResponseDto.of(userTicket, memberInfo);
                 })
+                .sorted(Comparator.comparing(UnapprovedUserTicketListResponseDto::getCreatedAt).reversed())
                 .toList();
     }
 

--- a/root/ticket-service/src/test/java/com/example/ticketservice/MemberFixture.java
+++ b/root/ticket-service/src/test/java/com/example/ticketservice/MemberFixture.java
@@ -1,0 +1,11 @@
+package com.example.ticketservice;
+
+import com.example.ticketservice.client.dto.response.MemberInfoResponseDto;
+
+public class MemberFixture {
+    public static MemberInfoResponseDto defaultMemberInfoResponse() {
+        return new MemberInfoResponseDto("홍길동", "010-1234-5678");
+    }
+
+
+}

--- a/root/ticket-service/src/test/java/com/example/ticketservice/lecturereservation/LectureReservationAcceptanceTest.java
+++ b/root/ticket-service/src/test/java/com/example/ticketservice/lecturereservation/LectureReservationAcceptanceTest.java
@@ -6,10 +6,9 @@ import com.example.ticketservice.dto.BaseResponseDto;
 import com.example.ticketservice.fixture.CenterFixture;
 import com.example.ticketservice.fixture.TicketFixture;
 import com.example.ticketservice.service.AmazonS3Service;
-import com.example.ticketservice.ticket.AdminTicketSteps;
-import com.example.ticketservice.ticket.TicketSteps;
+import com.example.ticketservice.ticket.utils.AdminTicketSteps;
+import com.example.ticketservice.ticket.utils.TicketSteps;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.web.multipart.MultipartFile;
 

--- a/root/ticket-service/src/test/java/com/example/ticketservice/ticket/acceptance/TicketAcceptanceTest.java
+++ b/root/ticket-service/src/test/java/com/example/ticketservice/ticket/acceptance/TicketAcceptanceTest.java
@@ -1,16 +1,18 @@
-package com.example.ticketservice.ticket;
+package com.example.ticketservice.ticket.acceptance;
 
 import com.example.ticketservice.AcceptanceTest;
-import com.example.ticketservice.dto.response.AdminReviewTicketResponseDto;
-import com.example.ticketservice.dto.response.TicketDetailResponseDto;
-import com.example.ticketservice.dto.response.TicketResponseDto;
+import com.example.ticketservice.MemberFixture;
+import com.example.ticketservice.client.MemberServiceClient;
+import com.example.ticketservice.dto.response.*;
 import com.example.ticketservice.fixture.CenterFixture;
 import com.example.ticketservice.fixture.ReviewFixture;
 import com.example.ticketservice.fixture.TicketFixture;
 import com.example.ticketservice.client.CompanyServiceClient;
 import com.example.ticketservice.dto.BaseResponseDto;
-import com.example.ticketservice.dto.response.TicketCreateResponseDto;
 import com.example.ticketservice.service.AmazonS3Service;
+import com.example.ticketservice.ticket.utils.AdminTicketSteps;
+import com.example.ticketservice.ticket.utils.ReviewSteps;
+import com.example.ticketservice.ticket.utils.TicketSteps;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -26,6 +28,9 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 public class TicketAcceptanceTest extends AcceptanceTest {
     @MockBean
     private CompanyServiceClient companyServiceClient;
+
+    @MockBean
+    private MemberServiceClient memberServiceClient;
 
     @MockBean
     private AmazonS3Service amazonS3Service;
@@ -98,11 +103,28 @@ public class TicketAcceptanceTest extends AcceptanceTest {
         // when
         mockForGetTicketDetail();
         Long userTicketId = TicketSteps.purchaseTicket(ticketId);
-        TicketDetailResponseDto ticket = AdminTicketSteps.getTicketDetail(ticketId);
 
         // then
         assertThat(userTicketId).isNotNull();
-        assertThat(ticket.getIssueCount()).isEqualTo(1);
+    }
+
+    @Test
+    public void getUnapprovedUserTicketListSuccess() throws Exception {
+        // given
+        long centerId = 1L;
+
+        mockForCreateTicket();
+        long ticketId = AdminTicketSteps.createTicket(centerId, TicketFixture.defaultTicketCreateRequest()).getTicketId();
+        AdminTicketSteps.uploadTicket(ticketId);
+        Long userTicketId = TicketSteps.purchaseTicket(ticketId);
+
+        // when
+        given(memberServiceClient.getMemberInfo(anyLong())).willReturn(new BaseResponseDto<>(MemberFixture.defaultMemberInfoResponse()));
+        List<UnapprovedUserTicketListResponseDto> response = AdminTicketSteps.getUnapprovedUserTicketList(centerId);
+
+        // then
+        assertThat(response.size()).isEqualTo(1);
+        assertThat(response.get(0).getUserTicketId()).isEqualTo(userTicketId);
     }
 
     private void mockForCreateTicket() throws IOException {
@@ -115,4 +137,5 @@ public class TicketAcceptanceTest extends AcceptanceTest {
         given(companyServiceClient.getOriginalCenterInfo(anyLong())).willReturn(new BaseResponseDto<>(CenterFixture.defaultOriginalCenterResponseDto()));
         given(companyServiceClient.getOriginalBusinessInfo(anyLong())).willReturn(new BaseResponseDto<>(CenterFixture.defaultOriginalBusinessResponseDto()));
     }
+
 }

--- a/root/ticket-service/src/test/java/com/example/ticketservice/ticket/utils/AdminTicketSteps.java
+++ b/root/ticket-service/src/test/java/com/example/ticketservice/ticket/utils/AdminTicketSteps.java
@@ -133,6 +133,15 @@ public class AdminTicketSteps {
         return objectMapper.readValue(dataNode.toString(), objectMapper.getTypeFactory().constructCollectionType(List.class, UnapprovedUserTicketListResponseDto.class));
     }
 
+    public static void approveUserTicket(long userTicketId) {
+        RestAssured
+                .given().log().all()
+                .when()
+                .patch("/api/v1/admin/tickets/members/{userTicketId}/approve", userTicketId)
+                .then().log().all()
+                .statusCode(200);
+    }
+
     private static File generateMockImageFile() throws IOException {
         File tempFile = File.createTempFile("test", ".jpg");
         tempFile.deleteOnExit();

--- a/root/ticket-service/src/test/java/com/example/ticketservice/ticket/utils/AdminTicketSteps.java
+++ b/root/ticket-service/src/test/java/com/example/ticketservice/ticket/utils/AdminTicketSteps.java
@@ -1,4 +1,4 @@
-package com.example.ticketservice.ticket;
+package com.example.ticketservice.ticket.utils;
 
 import com.example.ticketservice.dto.request.TicketCreateRequestDto;
 import com.example.ticketservice.dto.response.*;
@@ -114,6 +114,23 @@ public class AdminTicketSteps {
                 .patch("/api/v1/admin/tickets/management/{ticketId}/upload", ticketId)
                 .then().log().all()
                 .statusCode(200);
+    }
+
+    public static List<UnapprovedUserTicketListResponseDto> getUnapprovedUserTicketList(long centerId) throws JsonProcessingException {
+        objectMapper.registerModule(new JavaTimeModule());
+
+        String responseBody = RestAssured
+                .given().log().all()
+                .when()
+                .get("/api/v1/admin/tickets/members/unapproved/{centerId}", centerId)
+                .then().log().all()
+                .statusCode(200)
+                .extract().asString();
+
+        JsonNode responseJson = objectMapper.readTree(responseBody);
+        JsonNode dataNode = responseJson.get("data");
+
+        return objectMapper.readValue(dataNode.toString(), objectMapper.getTypeFactory().constructCollectionType(List.class, UnapprovedUserTicketListResponseDto.class));
     }
 
     private static File generateMockImageFile() throws IOException {

--- a/root/ticket-service/src/test/java/com/example/ticketservice/ticket/utils/ReviewSteps.java
+++ b/root/ticket-service/src/test/java/com/example/ticketservice/ticket/utils/ReviewSteps.java
@@ -1,4 +1,4 @@
-package com.example.ticketservice.ticket;
+package com.example.ticketservice.ticket.utils;
 
 import com.example.ticketservice.dto.request.ReviewRequestDto;
 import com.fasterxml.jackson.databind.JsonNode;

--- a/root/ticket-service/src/test/java/com/example/ticketservice/ticket/utils/TicketSteps.java
+++ b/root/ticket-service/src/test/java/com/example/ticketservice/ticket/utils/TicketSteps.java
@@ -1,4 +1,4 @@
-package com.example.ticketservice.ticket;
+package com.example.ticketservice.ticket.utils;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;


### PR DESCRIPTION
- 관리자용 이용권과 사용자용 이용권 컨트롤러 분리
- 이용권 신청 회원 목록 조회 일부 구현(MemberServiceClient로 회원의 정보 조회하는 API 추후 구현 필요)
- 이용권 승인 구현
- 구현한 기능 인수테스트 작성