### PR TITLE
feat: swagger api docs ui 적용

### DIFF
--- a/root/company-service/build.gradle
+++ b/root/company-service/build.gradle
@@ -51,6 +51,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
 
     implementation group: 'com.google.code.gson', name: 'gson', version: '2.10.1'
+
+    // swagger
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 }
 
 def querydslSrcDir = 'src/main/generated'

--- a/root/company-service/src/main/java/com/example/companyservice/admin/controller/ApproveController.java
+++ b/root/company-service/src/main/java/com/example/companyservice/admin/controller/ApproveController.java
@@ -3,6 +3,9 @@ package com.example.companyservice.admin.controller;
 import com.example.companyservice.admin.dto.response.CompanyApplyResponseDto;
 import com.example.companyservice.admin.service.ApproveService;
 import com.example.companyservice.common.dto.BaseResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -12,21 +15,26 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/approve")
+@RequestMapping("/api/v1/admin/approve")
+@Tag(name = "어드민 승인요청", description = "어드민 내 승인 페이지")
 public class ApproveController {
 
     private final ApproveService approveService;
 
     @GetMapping("/company/apply")
+    @Operation(summary = "입점 요청 승인 시설 조회", description = "최신 등록순으로 시설 조회")
     public ResponseEntity<BaseResponseDto<List<CompanyApplyResponseDto>>> getCompanyApplyInfo() {
         return ResponseEntity.status(HttpStatus.OK)
                 .body(new BaseResponseDto<>(approveService.getCompanyApplyInfo()));
     }
 
     @PatchMapping("/company/apply/accept/{companyId}/{answer}")
-    public ResponseEntity<BaseResponseDto<Long>> respondCompany(@PathVariable(name = "companyId") long companyId,
-                                                               @PathVariable(name = "answer") String answer) {
+    @Operation(summary = "입점 요청 시설 승인 갱신")
+    public ResponseEntity<BaseResponseDto<Long>> respondCompany(@Parameter(description = "시설 ID") @PathVariable(name = "companyId") long companyId,
+                                                                @Parameter(description = "상태") @PathVariable(name = "answer") String answer) {
         return ResponseEntity.status(HttpStatus.OK)
                 .body(new BaseResponseDto<>(approveService.respondCompany(companyId, answer)));
     }
 }
+
+

--- a/root/company-service/src/main/java/com/example/companyservice/config/SwaggerConfig.java
+++ b/root/company-service/src/main/java/com/example/companyservice/config/SwaggerConfig.java
@@ -1,0 +1,43 @@
+package com.example.companyservice.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springdoc.core.models.GroupedOpenApi;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI api() {
+        return new OpenAPI()
+                .components(new Components())
+                .info(apiInfo());
+    }
+
+    //도메인으로 그룹화
+    @Bean
+    public GroupedOpenApi companyApi() {
+        return GroupedOpenApi.builder()
+                .group("company-service")
+                .pathsToMatch("/api/v1/**")
+                .build();
+    }
+
+    @Bean
+    public GroupedOpenApi adminApi() {
+        return GroupedOpenApi.builder()
+                .group("어드민 페이지")
+                .pathsToMatch("/api/v1/admin/**")
+                .build();
+    }
+
+    private Info apiInfo() {
+        return new Info()
+                .title("COMPANY-SERVICE API DOCS")
+                .description("company-service rest api")
+                .version("1.0.0");
+    }
+}


### PR DESCRIPTION
#144 
company-service 내 swagger 적용 완료
테스트로 company-service에만 적용해둔 상태이며, 필요시 동일하게 적용할 수 있습니다. 
주소: 서버:포트/swagger-ui/index.html#/

api 문서는 각 서비스에서 만들어지고, 랜덤포트로 url이 생성되어 각각 접근해야하기 때문에 서비스가 많아질수록 여러개의 swagger 페이지를 띄우고 봐야하는 상황...
통합 swagger 적용도 가능하지만, 서버 구축 및 고려 사항이 필요하여 좀 더 조사해보도록 하겠습니다.