### PR TITLE
config: 분산 로그 traceId 출력되게 적용

### DIFF
--- a/root/api-gateway-server/build.gradle
+++ b/root/api-gateway-server/build.gradle
@@ -21,6 +21,10 @@ dependencies {
 
     // swagger
     implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webflux-ui', version: '2.2.0'
+
+    // Logging
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.micrometer:micrometer-tracing-bridge-brave'
 }
 
 dependencyManagement {

--- a/root/api-gateway-server/src/main/resources/application.yml
+++ b/root/api-gateway-server/src/main/resources/application.yml
@@ -133,3 +133,9 @@ spring:
 
   profiles:
     include: secret, swagger
+
+# 로그에 traceId 추가
+management:
+  tracing:
+    propagation:
+      type: b3

--- a/root/company-service/build.gradle
+++ b/root/company-service/build.gradle
@@ -57,6 +57,10 @@ dependencies {
 
     // kafka
     implementation 'org.springframework.kafka:spring-kafka'
+
+    // Logging
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.micrometer:micrometer-tracing-bridge-brave'
 }
 
 def querydslSrcDir = 'src/main/generated'

--- a/root/company-service/src/main/resources/application.yml
+++ b/root/company-service/src/main/resources/application.yml
@@ -32,3 +32,8 @@ eureka:
 logging:
   level:
     com.example.companyservice.client: DEBUG
+
+management:
+  tracing:
+    propagation:
+      type: b3

--- a/root/discovery-server/build.gradle
+++ b/root/discovery-server/build.gradle
@@ -5,6 +5,9 @@ ext {
 dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-server'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
+    // Logging
+    implementation 'io.micrometer:micrometer-tracing-bridge-brave'
 }
 
 dependencyManagement {

--- a/root/discovery-server/src/main/resources/application.yml
+++ b/root/discovery-server/src/main/resources/application.yml
@@ -4,6 +4,10 @@ server:
 spring:
   application:
     name: discovery-server
+  cloud:
+    openfeign:
+      micrometer:
+        enabled: true
 
 eureka:
   client:
@@ -11,3 +15,9 @@ eureka:
     fetch-registry: false
     service-url:
       defaultZone: http://localhost:${server.port}/eureka
+
+# 로그에 traceId 추가
+management:
+  tracing:
+    propagation:
+      type: b3

--- a/root/ticket-service/build.gradle
+++ b/root/ticket-service/build.gradle
@@ -38,6 +38,10 @@ dependencies {
 
     // swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+
+    // Logging
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.micrometer:micrometer-tracing-bridge-brave'
 }
 
 def querydslSrcDir = 'src/main/generated'

--- a/root/ticket-service/src/main/java/com/example/ticketservice/common/aop/LogAop.java
+++ b/root/ticket-service/src/main/java/com/example/ticketservice/common/aop/LogAop.java
@@ -1,0 +1,24 @@
+package com.example.ticketservice.common.aop;
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.After;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Aspect
+@Component
+public class LogAop {
+
+    @Before("execution(* com.example.ticketservice..*(..)) && !execution(* com.example.ticketservice.common..*(..))")
+    public void before(JoinPoint joinPoint){
+        log.info("[log] {} -> {} 실행", joinPoint.getSignature().getDeclaringType().getSimpleName() ,joinPoint.getSignature().getName());
+    }
+
+    @After("execution(* com.example.ticketservice..*(..)) && !execution(* com.example.ticketservice.common..*(..))")
+    public void after(JoinPoint joinPoint){
+        log.info("[log] {} -> {} 종료", joinPoint.getSignature().getDeclaringType().getSimpleName() ,joinPoint.getSignature().getName());
+    }
+}

--- a/root/ticket-service/src/main/resources/application.yml
+++ b/root/ticket-service/src/main/resources/application.yml
@@ -40,3 +40,9 @@ eureka:
 logging:
   level:
     com.example.ticketservice.client: DEBUG
+
+# 로그에 traceId 추가
+management:
+  tracing:
+    propagation:
+      type: b3


### PR DESCRIPTION
- 마이크로서비스의 경우 같은 요청에 대한 로그이더라도 그걸 식별할 방법이 없어서 traceId 추가
- ticket-service에도 LogAop 추가